### PR TITLE
Fix overflow on 32bits platform (i.e. WASM32)

### DIFF
--- a/src/crypto/merkle/proof_verification.rs
+++ b/src/crypto/merkle/proof_verification.rs
@@ -208,7 +208,7 @@ where
     }
 
     fn inner_proof_size(index: usize, tree_size: usize) -> usize {
-        u64::BITS as usize - ((index ^ (tree_size - 1)).leading_zeros() as usize)
+        usize::BITS as usize - ((index ^ (tree_size - 1)).leading_zeros() as usize)
     }
 }
 


### PR DESCRIPTION
Small patch to fix overflows on 32bits platform. When compiling to WASM32, line 206 will overflow during the bit shift.

@jasperpatterson 