### PR TITLE
Bump openidconnect to v4 and tough to 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ sigstore_protobuf_specs = { version = "0.3.2", optional = true }
 thiserror = "1.0.30"
 tokio = { version = "1.17.0", features = ["rt"] }
 tokio-util = { version = "0.7.10", features = ["io-util"] }
-tough = { version = "0.17.1", features = ["http"], optional = true }
+tough = { version = "0.19.0", features = ["http"], optional = true }
 tracing = "0.1.31"
 url = "2.2.2"
 x509-cert = { version = "0.2.5", features = ["builder", "pem", "std", "sct"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,9 @@ futures-util = { version = "0.3.30", optional = true }
 lazy_static = "1.4.0"
 oci-distribution = { version = "0.11", default-features = false, optional = true }
 olpc-cjson = { version = "0.1", optional = true }
-openidconnect = { version = "3.0", default-features = false, features = [
+openidconnect = { version = "4.0", default-features = false, features = [
   "reqwest",
+  "reqwest-blocking"
 ], optional = true }
 p256 = "0.13"
 p384 = "0.13"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -200,6 +200,10 @@ pub enum SigstoreError {
     #[error("Verification of OIDC claims received from OpenIdProvider failed")]
     ClaimsVerificationError,
 
+    #[cfg(feature = "oauth")]
+    #[error("Claims configuration error: {0}")]
+    ClaimsConfigurationError(#[from] openidconnect::ConfigurationError),
+
     #[error("Failed to access token endpoint")]
     ClaimsAccessPointError,
 

--- a/src/oauth/openidflow.rs
+++ b/src/oauth/openidflow.rs
@@ -84,21 +84,26 @@ use crate::errors::{Result, SigstoreError};
 use tracing::error;
 
 use openidconnect::core::{
-    CoreClient, CoreIdToken, CoreIdTokenClaims, CoreIdTokenVerifier, CoreProviderMetadata,
-    CoreResponseType, CoreTokenResponse,
+    CoreAuthenticationFlow, CoreClient, CoreIdToken, CoreIdTokenClaims, CoreIdTokenVerifier,
+    CoreProviderMetadata, CoreResponseType, CoreTokenResponse,
 };
-use openidconnect::reqwest::async_http_client;
 use openidconnect::{
-    AuthenticationFlow, AuthorizationCode, ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce,
-    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope,
+    AuthenticationFlow, AuthorizationCode, ClientId, ClientSecret, CsrfToken, EndpointNotSet,
+    EndpointSet, IssuerUrl, Nonce, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope,
 };
-
-#[cfg(not(target_arch = "wasm32"))]
-use openidconnect::reqwest::http_client;
 
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
 use url::Url;
+
+pub(crate) type OpenIdClient = openidconnect::core::CoreClient<
+    openidconnect::EndpointSet,      // HasAuthUrl
+    openidconnect::EndpointNotSet,   // HasDeviceAuthUrl
+    openidconnect::EndpointNotSet,   // HasIntrospectionUrl
+    openidconnect::EndpointNotSet,   // HasRevocationUrl
+    openidconnect::EndpointMaybeSet, // HasTokenUrl
+    openidconnect::EndpointMaybeSet, // HasUserInfoUrl
+>;
 
 #[derive(Debug)]
 pub struct OpenIDAuthorize {
@@ -136,7 +141,7 @@ impl OpenIDAuthorize {
     fn auth_url_internal(
         &self,
         provider_metadata: CoreProviderMetadata,
-    ) -> Result<(Url, CoreClient, Nonce, PkceCodeVerifier)> {
+    ) -> Result<(Url, OpenIdClient, Nonce, PkceCodeVerifier)> {
         let client_id = ClientId::new(self.oidc_cliend_id.to_owned());
         let client_secret = ClientSecret::new(self.oidc_client_secret.to_owned());
 
@@ -150,7 +155,7 @@ impl OpenIDAuthorize {
 
         let (authorize_url, _, nonce) = client
             .authorize_url(
-                AuthenticationFlow::<CoreResponseType>::AuthorizationCode,
+                CoreAuthenticationFlow::AuthorizationCode,
                 CsrfToken::new_random,
                 Nonce::new_random,
             )
@@ -161,11 +166,16 @@ impl OpenIDAuthorize {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn auth_url(&self) -> Result<(Url, CoreClient, Nonce, PkceCodeVerifier)> {
+    pub fn auth_url(&self) -> Result<(Url, OpenIdClient, Nonce, PkceCodeVerifier)> {
+        let http_client = reqwest::blocking::ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+
         let issuer = IssuerUrl::new(self.oidc_issuer.to_owned()).expect("Missing the OIDC_ISSUER.");
 
         let provider_metadata =
-            CoreProviderMetadata::discover(&issuer, http_client).map_err(|err| {
+            CoreProviderMetadata::discover(&issuer, &http_client).map_err(|err| {
                 error!("Error is: {:?}", err);
                 SigstoreError::ClaimsVerificationError
             })?;
@@ -173,10 +183,15 @@ impl OpenIDAuthorize {
         self.auth_url_internal(provider_metadata)
     }
 
-    pub async fn auth_url_async(&self) -> Result<(Url, CoreClient, Nonce, PkceCodeVerifier)> {
+    pub async fn auth_url_async(&self) -> Result<(Url, OpenIdClient, Nonce, PkceCodeVerifier)> {
+        let async_http_client = reqwest::ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+
         let issuer = IssuerUrl::new(self.oidc_issuer.to_owned()).expect("Missing the OIDC_ISSUER.");
 
-        let provider_metadata = CoreProviderMetadata::discover_async(issuer, async_http_client)
+        let provider_metadata = CoreProviderMetadata::discover_async(issuer, &async_http_client)
             .await
             .map_err(|_| SigstoreError::ClaimsVerificationError)?;
 
@@ -186,7 +201,7 @@ impl OpenIDAuthorize {
 
 pub struct RedirectListener {
     client_redirect_host: String,
-    client: CoreClient,
+    client: OpenIdClient,
     nonce: Nonce,
     pkce_verifier: PkceCodeVerifier,
 }
@@ -197,7 +212,7 @@ impl RedirectListener {
     //! # Arguments
     //!
     //! * `client_redirect_host` - The client callback host IP:PORT
-    //! * `client` - CoreClient instance (returned from OpenIDAuthorize)
+    //! * `client` - OpenIdClient instance (returned from OpenIDAuthorize)
     //! * `nonce` - Nonce (returned from OpenIDAuthorize)
     //! * `pkce_verifier` - client redirect URL
     //! # Example
@@ -209,7 +224,7 @@ impl RedirectListener {
     //! ```
     pub fn new(
         client_redirect_host: &str,
-        client: CoreClient,
+        client: OpenIdClient,
         nonce: Nonce,
         pkce_verifier: PkceCodeVerifier,
     ) -> Self {
@@ -274,13 +289,20 @@ impl RedirectListener {
 
     #[cfg(not(target_arch = "wasm32"))]
     pub fn redirect_listener(self) -> Result<(CoreIdTokenClaims, CoreIdToken)> {
+        use openidconnect::reqwest::blocking::ClientBuilder;
+
+        let http_client = ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+
         let code = self.redirect_listener_internal()?;
 
         let token_response = self
             .client
-            .exchange_code(code)
+            .exchange_code(code)?
             .set_pkce_verifier(self.pkce_verifier)
-            .request(http_client)
+            .request(&http_client)
             .map_err(|_| SigstoreError::ClaimsAccessPointError)?;
 
         Self::extract_token_and_claims(
@@ -291,13 +313,20 @@ impl RedirectListener {
     }
 
     pub async fn redirect_listener_async(self) -> Result<(CoreIdTokenClaims, CoreIdToken)> {
+        use openidconnect::reqwest::ClientBuilder;
+
+        let async_http_client = ClientBuilder::new()
+            // Following redirects opens the client up to SSRF vulnerabilities.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()?;
+
         let code = self.redirect_listener_internal()?;
 
         let token_response = self
             .client
-            .exchange_code(code)
+            .exchange_code(code)?
             .set_pkce_verifier(self.pkce_verifier)
-            .request_async(async_http_client)
+            .request_async(&async_http_client)
             .await
             .map_err(|_| SigstoreError::ClaimsAccessPointError)?;
 


### PR DESCRIPTION
Cherry-pick of https://github.com/sigstore/sigstore-rs/commit/95ee86371ac07510b9e6c7dc030770e41f79b9a4, which upgrades openidconnect to 4.0.0. Also bumps tough to 0.19. 

This allows us to remove an old dependency to reqwest 0.11.