### PR TITLE
Remove dependency on webbrowser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,6 @@ openidconnect = { version = "4.0", default-features = false, features = [
 ], optional = true }
 p256 = "0.13"
 p384 = "0.13"
-webbrowser = "1.0.1"
 pem = { version = "3.0", features = ["serde"] }
 pkcs1 = { version = "0.7.5", features = ["std"] }
 pkcs8 = { version = "0.10.2", features = [

--- a/examples/openidflow/openidconnect/main.rs
+++ b/examples/openidflow/openidconnect/main.rs
@@ -27,7 +27,6 @@ fn main() -> Result<(), anyhow::Error> {
 
     match oidc_url.as_ref() {
         Ok(url) => {
-            webbrowser::open(url.0.as_ref())?;
             println!(
                 "Open this URL in a browser if it does not automatically open for you:\n{}\n",
                 url.0

--- a/src/fulcio/oauth.rs
+++ b/src/fulcio/oauth.rs
@@ -90,7 +90,6 @@ impl OauthTokenProvider {
 
         match oidc_url.as_ref() {
             Ok(url) => {
-                webbrowser::open(url.0.as_ref())?;
                 println!(
                     "Open this URL in a browser if it does not automatically open for you:\n{}\n",
                     url.0,


### PR DESCRIPTION
I'm removing the dependency on webbrowser. Since this is not used, it's much easier to simply remove this dependency from the tree than removing all the unused code for now. 