### PR TITLE
Remove fulcio and rekor api client from verify feature set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ rekor-rustls-tls = ["reqwest/rustls-tls", "rekor"]
 rekor = ["reqwest"]
 
 sign = ["sigstore_protobuf_specs", "fulcio", "rekor", "cert"]
-verify = ["sigstore_protobuf_specs", "fulcio", "rekor", "cert"]
+verify = ["sigstore_protobuf_specs", "rekor", "cert"]
 bundle = ["sign", "verify"]
 
 sigstore-trust-root = ["sigstore_protobuf_specs", "futures-util", "tough", "regex", "tokio/sync"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,10 +38,11 @@ fulcio = ["oauth", "serde_with"]
 
 rekor-native-tls = ["reqwest/native-tls", "rekor"]
 rekor-rustls-tls = ["reqwest/rustls-tls", "rekor"]
-rekor = ["reqwest"]
+rekor = ["reqwest", "rekor-models"]
+rekor-models = []
 
 sign = ["sigstore_protobuf_specs", "fulcio", "rekor", "cert"]
-verify = ["sigstore_protobuf_specs", "rekor", "cert"]
+verify = ["sigstore_protobuf_specs", "rekor-models", "cert"]
 bundle = ["sign", "verify"]
 
 sigstore-trust-root = ["sigstore_protobuf_specs", "futures-util", "tough", "regex", "tokio/sync"]

--- a/src/bundle/verify/verifier.rs
+++ b/src/bundle/verify/verifier.rs
@@ -26,7 +26,6 @@ use crate::{
     bundle::Bundle,
     crypto::{CertificatePool, CosignVerificationKey, Signature, SigningScheme},
     errors::Result as SigstoreResult,
-    rekor::apis::configuration::Configuration as RekorConfiguration,
     trust::TrustRoot,
 };
 
@@ -42,28 +41,25 @@ use super::{
 /// An asynchronous Sigstore verifier.
 ///
 /// For synchronous usage, see [`Verifier`].
-pub struct Verifier<'a> {
+pub struct Verifier<'a, T> {
     #[allow(dead_code)]
-    rekor_config: RekorConfiguration,
+    online_verifier: T,
     rekor_key: CosignVerificationKey,
     cert_pool: CertificatePool<'a>,
 }
 
-impl<'a> Verifier<'a> {
+impl<'a, T> Verifier<'a, T> {
     /// Constructs a [`Verifier`].
     ///
     /// For verifications against the public-good trust root, use [`Verifier::production()`].
-    pub fn new<R: TrustRoot>(
-        rekor_config: RekorConfiguration,
-        trust_repo: R,
-    ) -> SigstoreResult<Self> {
+    pub fn new<R: TrustRoot>(online_verifier: T, trust_repo: R) -> SigstoreResult<Self> {
         let cert_pool = CertificatePool::from_certificates(trust_repo.fulcio_certs()?, [])?;
         let rekor_key_bytes = trust_repo.rekor_keys().unwrap()[0];
         let rekor_key =
             CosignVerificationKey::from_pem(rekor_key_bytes, &SigningScheme::default()).unwrap();
 
         Ok(Self {
-            rekor_config,
+            online_verifier,
             rekor_key,
             cert_pool,
         })
@@ -171,7 +167,6 @@ impl<'a> Verifier<'a> {
             .verify_inclusion(log_entry, &self.rekor_key)
             .map_err(SignatureErrorKind::VerificationFailed)?;
 
-
         // 6) Verify the Signed Entry Timestamp (SET) supplied by Rekor for this
         //    artifact.
         // TODO(tnytown) SET verification; sigstore-rs#285
@@ -240,13 +235,13 @@ impl<'a> Verifier<'a> {
     }
 }
 
-impl<'a> Verifier<'a> {
+impl<'a> Verifier<'a, ()> {
     /// Constructs an [`Verifier`] against the public-good trust root.
     #[cfg(feature = "sigstore-trust-root")]
-    pub async fn production() -> SigstoreResult<Verifier<'static>> {
+    pub async fn production() -> SigstoreResult<Verifier<'static, ()>> {
         let updater = SigstoreTrustRoot::new(None).await?;
 
-        Verifier::new(Default::default(), updater)
+        Verifier::new((), updater)
     }
 }
 
@@ -254,23 +249,20 @@ pub mod blocking {
     use super::{Verifier as AsyncVerifier, *};
 
     /// A synchronous Sigstore verifier.
-    pub struct Verifier<'a> {
-        inner: AsyncVerifier<'a>,
+    pub struct Verifier<'a, T> {
+        inner: AsyncVerifier<'a, T>,
         rt: tokio::runtime::Runtime,
     }
 
-    impl<'a> Verifier<'a> {
+    impl<'a, T> Verifier<'a, T> {
         /// Constructs a synchronous Sigstore verifier.
         ///
         /// For verifications against the public-good trust root, use [`Verifier::production()`].
-        pub fn new<R: TrustRoot>(
-            rekor_config: RekorConfiguration,
-            trust_repo: R,
-        ) -> SigstoreResult<Self> {
+        pub fn new<R: TrustRoot>(online_verifier: T, trust_repo: R) -> SigstoreResult<Self> {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            let inner = AsyncVerifier::new(rekor_config, trust_repo)?;
+            let inner = AsyncVerifier::new(online_verifier, trust_repo)?;
 
             Ok(Self { rt, inner })
         }
@@ -317,10 +309,10 @@ pub mod blocking {
         }
     }
 
-    impl<'a> Verifier<'a> {
+    impl<'a> Verifier<'a, ()> {
         /// Constructs a synchronous [`Verifier`] against the public-good trust root.
         #[cfg(feature = "sigstore-trust-root")]
-        pub fn production() -> SigstoreResult<Verifier<'a>> {
+        pub fn production() -> SigstoreResult<Verifier<'a, ()>> {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;

--- a/src/crypto/certificate.rs
+++ b/src/crypto/certificate.rs
@@ -29,6 +29,7 @@ use crate::errors::{Result, SigstoreError};
 /// The following checks are performed against the given certificate:
 /// * The certificate has the right set of key usages
 /// * The certificate cannot be used before the current time
+#[allow(dead_code)]
 pub(crate) fn is_trusted(certificate: &Certificate, integrated_time: i64) -> Result<()> {
     verify_key_usages(certificate)?;
     verify_has_san(certificate)?;

--- a/src/crypto/certificate_pool.rs
+++ b/src/crypto/certificate_pool.rs
@@ -25,6 +25,7 @@ use crate::errors::{Result as SigstoreResult, SigstoreError};
 #[derive(Default, Debug)]
 pub(crate) struct CertificatePool<'a> {
     trusted_roots: Vec<TrustAnchor<'a>>,
+    #[allow(dead_code)]
     intermediates: Vec<CertificateDer<'a>>,
 }
 
@@ -58,6 +59,7 @@ impl<'a> CertificatePool<'a> {
     /// Because of that the validity checks performed by this method are more
     /// relaxed. The validity checks are done inside of
     /// [`crate::crypto::verify_validity`] and [`crate::crypto::verify_expiration`].
+    #[allow(dead_code)]
     pub(crate) fn verify_pem_cert(
         &self,
         cert_pem: &[u8],
@@ -81,6 +83,7 @@ impl<'a> CertificatePool<'a> {
     /// Because of that the validity checks performed by this method are more
     /// relaxed. The validity checks are done inside of
     /// [`crate::crypto::verify_validity`] and [`crate::crypto::verify_expiration`].
+    #[allow(dead_code)]
     pub(crate) fn verify_der_cert(
         &self,
         der: &[u8],
@@ -98,6 +101,7 @@ impl<'a> CertificatePool<'a> {
         Ok(())
     }
 
+    #[allow(dead_code)]
     pub(crate) fn verify_cert_with_time<'cert>(
         &'a self,
         cert: &'cert EndEntityCert<'cert>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@
 //! }
 //! ```
 //! # Rekor integration
-//! The examples folder contains code that shows users how to make Rekor API calls.  
+//! The examples folder contains code that shows users how to make Rekor API calls.
 //! It also provides a clean interface with step-by-step instructions that other developers can copy and paste.
 //!
 //! ```rust,no_run
@@ -279,7 +279,7 @@ pub mod oauth;
 #[cfg(feature = "registry")]
 pub mod registry;
 
-#[cfg(feature = "rekor")]
+#[cfg(any(feature = "rekor", feature = "rekor-models"))]
 pub mod rekor;
 
 #[cfg(any(feature = "sign", feature = "verify"))]

--- a/src/rekor/mod.rs
+++ b/src/rekor/mod.rs
@@ -86,6 +86,9 @@
 //!- search_log_query
 //!
 
+#[cfg(feature = "rekor")]
 pub mod apis;
+
+#[cfg(feature = "rekor-models")]
 pub mod models;
 type TreeSize = i64;


### PR DESCRIPTION
When using only the verify feature set, we do not need to depend on fulcio directly. This still builds successfully and removes a significant amount of dependencies.

I've also decoupled the Verifier from rekor since we don't necessarily want to pull in reqwest when doing offline verification. All of it was unused code, so I replaced it with an unused `T`that could potentially be injected.