### PR TITLE
Add operator field to SearchIndex query struct

### DIFF
--- a/examples/rekor/search_index/main.rs
+++ b/examples/rekor/search_index/main.rs
@@ -109,6 +109,7 @@ async fn main() {
                 .unwrap_or(&HASH.to_string())
                 .to_owned(),
         ),
+        operator: None,
     };
     let configuration = Configuration::default();
 

--- a/src/rekor/models/search_index.rs
+++ b/src/rekor/models/search_index.rs
@@ -18,6 +18,8 @@ pub struct SearchIndex {
     pub public_key: Option<crate::rekor::models::search_index_public_key::SearchIndexPublicKey>,
     #[serde(rename = "hash", skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
+    #[serde(rename = "operator", skip_serializing_if = "Option::is_none")]
+    pub operator: Option<Operator>,
 }
 
 impl SearchIndex {
@@ -26,6 +28,15 @@ impl SearchIndex {
             email: None,
             public_key: None,
             hash: None,
+            operator: None,
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub enum Operator {
+    #[serde(rename = "and")]
+    And,
+    #[serde(rename = "or")]
+    Or,
 }


### PR DESCRIPTION
We need to set the operator in the `SearchIndex` query to `and` in order to find entries with the correct public key _and_ contents. That field exists in the [API spec](https://www.sigstore.dev/swagger/#/index/searchIndex), but not in the `SearchIndex` struct in this crate.

I've added it following the pattern of types in the crate.